### PR TITLE
Numeric type recognition should ignore content of parentheses

### DIFF
--- a/MySQLDump.php
+++ b/MySQLDump.php
@@ -124,7 +124,7 @@ class MySQLDump
 			while ($row = $res->fetch_assoc()) {
 				$col = $row['Field'];
 				$cols[] = '`' . str_replace('`', '``', $col) . '`';
-				$numeric[$col] = (bool) preg_match('#BYTE|COUNTER|SERIAL|INT|LONG|CURRENCY|REAL|MONEY|FLOAT|DOUBLE|DECIMAL|NUMERIC|NUMBER#i', $row['Type']);
+				$numeric[$col] = (bool) preg_match('#^[^(]*(BYTE|COUNTER|SERIAL|INT|LONG|CURRENCY|REAL|MONEY|FLOAT|DOUBLE|DECIMAL|NUMERIC|NUMBER)#i', $row['Type']);
 			}
 			$cols = '(' . implode(', ', $cols) . ')';
 			$res->close();


### PR DESCRIPTION
Original implementation would recognize type `ENUM('internal_something')` as a numeric column, as it contains "int".
