### PR TITLE
fixed export of views

### DIFF
--- a/src/MySQLDump.php
+++ b/src/MySQLDump.php
@@ -73,13 +73,19 @@ class MySQLDump
 			throw new Exception('Argument must be stream resource.');
 		}
 
-		$tables = array();
+		$tables = $views = array();
 
-		$res = $this->connection->query('SHOW TABLES');
+		$res = $this->connection->query('SHOW FULL TABLES');
 		while ($row = $res->fetch_row()) {
-			$tables[] = $row[0];
+			if ($row[1] === 'VIEW') {
+				$views[] = $row[0];
+			} else {
+				$tables[] = $row[0];
+			}
 		}
 		$res->close();
+
+		$tables = array_merge($tables, $views); // views must be last
 
 		$this->connection->query('LOCK TABLES `' . implode('` READ, `', $tables) . '` READ');
 


### PR DESCRIPTION
backported from clevis fork, views must be exported after all tables

From [documentation](https://dev.mysql.com/doc/refman/5.7/en/create-view.html):

> Any table or view referred to in the definition must exist. 